### PR TITLE
Jenkins 70768

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/openjdk_native/OpenJDKInstaller.java
+++ b/src/main/java/org/jenkinsci/plugins/openjdk_native/OpenJDKInstaller.java
@@ -18,7 +18,7 @@ import java.nio.charset.Charset;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
- * Auto-installer of native OpenJDK packages for RedHat-like distors
+ * Auto-installer of native OpenJDK packages for RedHat-like distros
  * Switch to required OpenJDK version via Linux alternatives. If required OpenJDK is not installed, try to install it via yum.
  * 
  * Alternatives and yum are run via sudo, therefore appropriate sudoers setup is requited (including switching off tty requirement). 
@@ -70,7 +70,7 @@ public class OpenJDKInstaller extends ToolInstaller{
         Launcher l = node.createLauncher(log);
         try (OpenJDKConsoleAnnotator annotator = new OpenJDKConsoleAnnotator(log.getLogger())) {
             PrintStream output = log.getLogger();
-            int exitStatus  = l.launch().cmds("sudo", "alternatives", "--set", "java", OPENJDK_HOME_PREFIX + openjdkPackage.getJreName() + OPENJDK_HOME_BIN).stdout(output).join();
+            int exitStatus  = l.launch().cmds("sudo", "alternatives", "--set", "java", OPENJDK_HOME_PREFIX + "$(rpm -q " + openjdkPackage.getPackageName() +" )"+ OPENJDK_HOME_BIN).stdout(output).join();
             if(exitStatus != 0){
                 byte[] errMsg = ("[OpenJDK ERROR] Switching OpenJDK via alternatives to " + openjdkPackage.getPackageName() + " failed! " + OPENJDK_BIN + " may not exists or point to different java version!\n").getBytes(Charset.defaultCharset());
                 annotator.eol(errMsg,errMsg.length);

--- a/src/main/java/org/jenkinsci/plugins/openjdk_native/OpenJDKInstaller.java
+++ b/src/main/java/org/jenkinsci/plugins/openjdk_native/OpenJDKInstaller.java
@@ -72,7 +72,7 @@ public class OpenJDKInstaller extends ToolInstaller{
             PrintStream output = log.getLogger();
             int exitStatus  = l.launch().cmds("sudo", "alternatives", "--set", "java", OPENJDK_HOME_PREFIX + openjdkPackage.getJreName() + OPENJDK_HOME_BIN).stdout(output).join();
             if(exitStatus != 0){
-                byte[] errMsg = ("[OpenJDK ERROR] Switching OpenJDK via atlernatives to " + openjdkPackage.getPackageName() + " failed! " + OPENJDK_BIN + " may not exists or point to different java version!\n").getBytes(Charset.defaultCharset());
+                byte[] errMsg = ("[OpenJDK ERROR] Switching OpenJDK via alternatives to " + openjdkPackage.getPackageName() + " failed! " + OPENJDK_BIN + " may not exists or point to different java version!\n").getBytes(Charset.defaultCharset());
                 annotator.eol(errMsg,errMsg.length);
             }
         } catch (IOException e){


### PR DESCRIPTION
bug fix for issue [JENKINS-70768]
https://issues.jenkins.io/browse/JENKINS-70768

creates a correct path  for alternatives --set

Instead of using
`sudo alternatives --set java /usr/lib/jvm/$(JRE-packagename)/bin/java`

The path is computed like this

`sudo alternatives --set java /usr/lib/jvm/$(rpm -q java-11-openjdk)/bin/java`